### PR TITLE
Add ability to set default zoom in JEI preview

### DIFF
--- a/src/main/java/eutros/multiblocktweaker/crafttweaker/CustomMultiblock.java
+++ b/src/main/java/eutros/multiblocktweaker/crafttweaker/CustomMultiblock.java
@@ -51,6 +51,12 @@ public class CustomMultiblock {
     public final RecipeMap<?> recipeMap;
 
     /**
+     * The default zoom level of the multiblock. Set in {@link MultiblockBuilder#withZoom(float)}
+     */
+    @ZenProperty
+    public final float zoom;
+
+    /**
      * Set to true if the multiblock should not check for energy inputs/outputs before forming.
      */
     @ZenProperty
@@ -121,6 +127,7 @@ public class CustomMultiblock {
     public CustomMultiblock(MultiblockBuilder builder) {
         metaId = builder.metaId;
         loc = builder.loc;
+        zoom = builder.zoom;
         pattern = builder.pattern;
         recipeMap = builder.recipeMap;
         texture = builder.texture;

--- a/src/main/java/eutros/multiblocktweaker/crafttweaker/construction/MultiblockBuilder.java
+++ b/src/main/java/eutros/multiblocktweaker/crafttweaker/construction/MultiblockBuilder.java
@@ -37,6 +37,7 @@ public class MultiblockBuilder {
 
     public ResourceLocation loc;
     public int metaId;
+    public float zoom;
     public gregtech.api.render.ICubeRenderer texture = null;
     public RecipeMap<?> recipeMap = null;
     public BlockPattern pattern = null;
@@ -104,6 +105,19 @@ public class MultiblockBuilder {
     @ZenMethod
     public MultiblockBuilder withTexture(@NotNull IICubeRenderer texture) {
         this.texture = texture.getInternal();
+        return this;
+    }
+
+    /**
+     * Set the default zoom level for the multiblock.
+     * This is optional, and if not defined will default to 1.0f
+     *
+     * @param zoom The default zoom level of the multiblock on the JEI preview page
+     * @return This builder, for convenience.
+     */
+    @ZenMethod
+    public MultiblockBuilder withZoom(float zoom) {
+        this.zoom = zoom;
         return this;
     }
 

--- a/src/main/java/eutros/multiblocktweaker/crafttweaker/construction/MultiblockBuilder.java
+++ b/src/main/java/eutros/multiblocktweaker/crafttweaker/construction/MultiblockBuilder.java
@@ -37,7 +37,7 @@ public class MultiblockBuilder {
 
     public ResourceLocation loc;
     public int metaId;
-    public float zoom;
+    public float zoom = 1.0f;
     public gregtech.api.render.ICubeRenderer texture = null;
     public RecipeMap<?> recipeMap = null;
     public BlockPattern pattern = null;

--- a/src/main/java/eutros/multiblocktweaker/jei/CustomInfoPage.java
+++ b/src/main/java/eutros/multiblocktweaker/jei/CustomInfoPage.java
@@ -33,4 +33,8 @@ public class CustomInfoPage extends MultiblockInfoPage {
         return new String[] { I18n.format(s) };
     }
 
+    @Override
+    public float getDefaultZoom() {
+        return multiblock.zoom;
+    }
 }


### PR DESCRIPTION
Adds the ability to set the default zoom level of multiblocks in the JEI preview using a new method `withZoom`

A demonstration image:
![javaw_2021-06-20_00-11-13](https://user-images.githubusercontent.com/31759736/122665438-0d950b00-d15c-11eb-9401-16f29884304d.png)
