### PR TITLE
remove reference to an IProperty that was migrate to a IUnlistedProperty

### DIFF
--- a/src/main/java/eutros/multiblocktweaker/crafttweaker/predicate/CTTraceabilityPredicate.java
+++ b/src/main/java/eutros/multiblocktweaker/crafttweaker/predicate/CTTraceabilityPredicate.java
@@ -180,7 +180,6 @@ public class CTTraceabilityPredicate {
         return new CTTraceabilityPredicate(blockWorldState -> {
             net.minecraft.block.state.IBlockState state = blockWorldState.getBlockState();
             if (state.getBlock() instanceof VariantActiveBlock) {
-                state = state.withProperty(VariantActiveBlock.ACTIVE, false);
                 blockWorldState.getMatchContext().getOrPut("VABlock", new LinkedList<>()).add(blockWorldState.getPos());
             }
             return states.contains(state);


### PR DESCRIPTION
fixes crash with GTCEu 2.4.3