### PR TITLE
GTCEu v2.4.4 compat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
 
 //    deobfCompile("gregtechce:gregtech:1.12.2:${properties["gt_ver"]}")
     "deobfCompile"("curse.maven:ae2-extended-life-570458:3649419")
-    "provided"(files("libs/gregtech-1.12.2-2.4.0-beta.jar"))
+    "provided"(files("libs/gregtech-1.12.2-2.4.4-beta.jar"))
 
     "deobfCompile"("codechicken:ChickenASM:1.12-1.0.2.9")
     "deobfCompile"("codechicken-lib-1-8:CodeChickenLib-1.12.2:3.2.3.358:universal")

--- a/src/main/java/eutros/multiblocktweaker/crafttweaker/gtwrap/impl/MCControllerTile.java
+++ b/src/main/java/eutros/multiblocktweaker/crafttweaker/gtwrap/impl/MCControllerTile.java
@@ -1,5 +1,6 @@
 package eutros.multiblocktweaker.crafttweaker.gtwrap.impl;
 
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.data.IData;
 import crafttweaker.api.world.IBlockPos;
 import eutros.multiblocktweaker.crafttweaker.CustomMultiblock;
@@ -145,11 +146,6 @@ public class MCControllerTile extends MCMetaTileEntity implements IControllerTil
     @Override
     public void formStructure(IPatternMatchContext context) {
         getInternal().formStructure(context.getInternal());
-    }
-
-    @Override
-    public int getLightValueForPart(IIMultiblockPart sourcePart) {
-        return getInternal().getLightValueForPart(sourcePart.getInternal());
     }
 
     @Override

--- a/src/main/java/eutros/multiblocktweaker/crafttweaker/gtwrap/impl/MCControllerTile.java
+++ b/src/main/java/eutros/multiblocktweaker/crafttweaker/gtwrap/impl/MCControllerTile.java
@@ -1,21 +1,9 @@
 package eutros.multiblocktweaker.crafttweaker.gtwrap.impl;
 
-import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.data.IData;
 import crafttweaker.api.world.IBlockPos;
 import eutros.multiblocktweaker.crafttweaker.CustomMultiblock;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IBlockPattern;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IControllerTile;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IICubeRenderer;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IIEnergyContainer;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IIItemHandlerModifiable;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IIMultiblockPart;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IIMultipleTankHandler;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IMultiblockAbility;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IMultiblockShapeInfo;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IPatternMatchContext;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IRecipe;
-import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.IRecipeLogic;
+import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.*;
 import eutros.multiblocktweaker.crafttweaker.predicate.CTTraceabilityPredicate;
 import eutros.multiblocktweaker.gregtech.tile.TileControllerCustom;
 import gregtech.api.recipes.RecipeMap;

--- a/src/main/java/eutros/multiblocktweaker/crafttweaker/gtwrap/interfaces/IControllerTile.java
+++ b/src/main/java/eutros/multiblocktweaker/crafttweaker/gtwrap/interfaces/IControllerTile.java
@@ -136,12 +136,17 @@ public interface IControllerTile extends IMetaTileEntity {
     void formStructure(IPatternMatchContext context);
 
     /**
+     * @deprecated
      * Get the light value of a specific part.
      * @param sourcePart The part block of this controller.
      * @return Light value.
      */
     @ZenMethod
-    int getLightValueForPart(IIMultiblockPart sourcePart);
+    @Deprecated
+    default int getLightValueForPart(IIMultiblockPart sourcePart) {
+        CraftTweakerAPI.logError("GTCEu 2.4.2 does no longer give light values to multiblocks parts.\n getLightValueForPart is deprecated an will always return 0.");
+        return 0;
+    }
 
     /**
      * Called when the structure is invalidated.

--- a/src/main/java/eutros/multiblocktweaker/crafttweaker/gtwrap/interfaces/IRecipeLogic.java
+++ b/src/main/java/eutros/multiblocktweaker/crafttweaker/gtwrap/interfaces/IRecipeLogic.java
@@ -49,8 +49,9 @@ public interface IRecipeLogic {
      * @return an int array of {OverclockedEUt, OverclockedDuration}
      */
     @ZenMethod
+    @Deprecated
     static int[] standardOverclockingLogic(int recipeEUt, long maximumVoltage, int recipeDuration, double durationDivisor, double voltageMultiplier, int maxOverclocks) {
-        return OverclockingLogic.standardOverclockingLogic( recipeEUt, maximumVoltage, recipeDuration, durationDivisor, voltageMultiplier, maxOverclocks );
+        return OverclockingLogic.standardOverclockingLogic(recipeEUt, maximumVoltage, recipeDuration, maxOverclocks, durationDivisor, voltageMultiplier);
     }
 
     // super method

--- a/src/main/java/eutros/multiblocktweaker/crafttweaker/gtwrap/interfaces/IRecipeLogic.java
+++ b/src/main/java/eutros/multiblocktweaker/crafttweaker/gtwrap/interfaces/IRecipeLogic.java
@@ -49,7 +49,6 @@ public interface IRecipeLogic {
      * @return an int array of {OverclockedEUt, OverclockedDuration}
      */
     @ZenMethod
-    @Deprecated
     static int[] standardOverclockingLogic(int recipeEUt, long maximumVoltage, int recipeDuration, double durationDivisor, double voltageMultiplier, int maxOverclocks) {
         return OverclockingLogic.standardOverclockingLogic(recipeEUt, maximumVoltage, recipeDuration, maxOverclocks, durationDivisor, voltageMultiplier);
     }


### PR DESCRIPTION
Provided CEu 2.4.4 instead of v2.4.0 in lib.

Fix a crash and compiling issue related to overclock logic, which Nomifactory needs in order to udpate.

Resolved another compiling issue due to the changes done by the VariantActiveBlock refactor.