### PR TITLE
Add support for machine sounds (requires GTNE 1.18.5+)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,7 +39,7 @@
  */
 dependencies {
     implementation rfg.deobf("curse.maven:codechicken-lib-1-8-242818:2779848")
-    implementation rfg.deobf("curse.maven:gregtech-nomifactory-edition-1019238:5411833") // GT Nomi 1.18.3
+    implementation rfg.deobf("curse.maven:gregtech-nomifactory-edition-1019238:6020404") // GT Nomi 1.18.5
 
     // Soft Dependencies
     implementation "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.684"

--- a/src/main/java/eutros/multiblocktweaker/crafttweaker/construction/RecipeMapBuilder.java
+++ b/src/main/java/eutros/multiblocktweaker/crafttweaker/construction/RecipeMapBuilder.java
@@ -1,5 +1,6 @@
 package eutros.multiblocktweaker.crafttweaker.construction;
 
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.annotations.ZenRegister;
 import eutros.multiblocktweaker.crafttweaker.gtwrap.constants.ConstantMoveType;
 import eutros.multiblocktweaker.crafttweaker.gtwrap.interfaces.ITextureArea;
@@ -291,8 +292,9 @@ public class RecipeMapBuilder {
         if (sound != null) {
             if(ForgeRegistries.SOUND_EVENTS.containsKey(sound))
                 map.setSound(ForgeRegistries.SOUND_EVENTS.getValue(sound));
+            else
+                CraftTweakerAPI.logError(String.format("Couldn't locate sound '%s'.", sound));
         }
-
         return map;
     }
 

--- a/src/main/java/eutros/multiblocktweaker/crafttweaker/construction/RecipeMapBuilder.java
+++ b/src/main/java/eutros/multiblocktweaker/crafttweaker/construction/RecipeMapBuilder.java
@@ -11,7 +11,9 @@ import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.gui.widgets.ProgressWidget;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.crafttweaker.CTRecipeBuilder;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
@@ -39,6 +41,7 @@ public class RecipeMapBuilder {
     private final TByteObjectMap<TextureArea> slotOverlays = new TByteObjectHashMap<>();
     private ProgressWidget.MoveType moveType = null;
     private TextureArea progressBarTexture = null;
+    private ResourceLocation sound = null;
 
     /**
      * Create a new, blank {@link CTRecipeBuilder} that can be used with {@link #setDefaultRecipe(CTRecipeBuilder)}.
@@ -246,6 +249,19 @@ public class RecipeMapBuilder {
     }
 
     /**
+     * Set the sound this machine will play while running. If the specified resource doesn't exist, it will not be
+     * applied.
+     *
+     * @param path the resource location of the sound to play, e.g. "gregtech:tick.macerator"
+     * @return This builder, for convenience.
+     */
+    @ZenMethod
+    public RecipeMapBuilder setSound(String path) {
+        sound = new ResourceLocation(path);
+        return this;
+    }
+
+    /**
      * Construct the {@link RecipeMap}.
      *
      * @return The built recipe map.
@@ -270,6 +286,11 @@ public class RecipeMapBuilder {
 
         if (progressBarTexture != null && moveType != null) {
             map.setProgressBar(progressBarTexture, moveType);
+        }
+
+        if (sound != null) {
+            if(ForgeRegistries.SOUND_EVENTS.containsKey(sound))
+                map.setSound(ForgeRegistries.SOUND_EVENTS.getValue(sound));
         }
 
         return map;


### PR DESCRIPTION
Support for Machine Sounds in custom multiblocks using GTNE 1.18.5+

Sound is specified on the RecipeMap using the resource name of the desired sound.

Example script usage:

```zs
// Builder.start(...
    .withRecipeMap(
        FactoryRecipeMap.start(loc)
                        .minFluidInputs(1)
                        .maxFluidInputs(1)
                        .maxFluidOutputs(6)
                        .setSound("gregtech:tick.boiler")
                        .build())
```