### PR TITLE
Fix crash from API change in GTNE 1.18.6

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,7 +39,7 @@
  */
 dependencies {
     implementation rfg.deobf("curse.maven:codechicken-lib-1-8-242818:2779848")
-    implementation rfg.deobf("curse.maven:gregtech-nomifactory-edition-1019238:6020404") // GT Nomi 1.18.5
+    implementation rfg.deobf("curse.maven:gregtech-nomifactory-edition-1019238:6309288") // GT Nomi 1.18.6
 
     // Soft Dependencies
     implementation "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.684"

--- a/src/main/java/eutros/multiblocktweaker/gregtech/recipes/CustomMultiblockRecipeLogic.java
+++ b/src/main/java/eutros/multiblocktweaker/gregtech/recipes/CustomMultiblockRecipeLogic.java
@@ -59,7 +59,7 @@ public class CustomMultiblockRecipeLogic extends MultiblockRecipeLogic implement
             return false;
         }
 
-        int[] resultOverclock = calculateOverclock(recipe.getEUt(), getMaxVoltage(), recipe.getDuration());
+        int[] resultOverclock = calculateOverclock(recipe);
         int totalEUt = resultOverclock[0] * resultOverclock[1];
         IItemHandlerModifiable importInventory = getInputInventory();
         IItemHandlerModifiable exportInventory = getOutputInventory();


### PR DESCRIPTION
Forgot about MultiblockTweaker potentially being affected when I changed the API for `AbstractRecipeLogic::calculateOverclocks` in GTNE 1.18.6.

Minor revision to fix the resulting crash.